### PR TITLE
feat: Improvement to the E2E tests framework - still flaky

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -223,6 +223,10 @@ jobs:
             -e ENV_DATABASE_PASSWORD=$DATABASE_PASSWORD \
             -p 1234:1234 \
             totocorpsoftwareinc/template-go:${{ needs.extract-service-tag.outputs.version }}
+
+          curl -v localhost:1234/v1/healthcheck
+          curl -s -w %{http_code} localhost:1234/v1/healthcheck
+
           echo "status_code=$(curl -s -o /dev/null -w %{http_code} localhost:1234/v1/healthcheck)" >> $GITHUB_OUTPUT
           echo "response_body=$(curl -s localhost:1234/v1/healthcheck)" >> $GITHUB_OUTPUT
           docker stop template-go-test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 
 # https://stackoverflow.com/questions/34712972/in-a-makefile-how-can-i-fetch-and-assign-a-git-commit-hash-to-a-variable
 GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD)
+SERVER_PORT=60004
+DATABASE_HOST=127.0.0.1
+DATABASE_PASSWORD="comes-from-the-environment"
 
 template-go-build:
 	docker build \
@@ -8,3 +11,12 @@ template-go-build:
 		--tag totocorpsoftwareinc/template-go:${GIT_COMMIT_HASH} \
 		-f build/template-go/Dockerfile \
 		.
+
+template-go-run:
+	docker run \
+		-e ENV_SERVER_PORT=${SERVER_PORT} \
+		-e ENV_DATABASE_HOST=${DATABASE_HOST} \
+		-e ENV_DATABASE_PASSWORD=${DATABASE_PASSWORD} \
+		-p 1234:1234 \
+		--network=host \
+		totocorpsoftwareinc/template-go:${GIT_COMMIT_HASH}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	conf, err := config.Load(determineConfigName(), internal.DefaultConfig())
 	if err != nil {
-		log.Errorf("Failed to create db connection: %v", err)
+		log.Errorf("Failed to load configuration: %v", err)
 		os.Exit(1)
 	}
 

--- a/database/Makefile
+++ b/database/Makefile
@@ -10,6 +10,14 @@ MIGRATION_STEPS ?= 1
 
 URL_ENCODED_PASSWORD=$(shell urlencode '${DB_PASSWORD}')
 
+# This target can be used to print commands to copy to set the environment
+# variables needed for passwords when creating users. This makes it faster
+# than having to type them by manually.
+printPasswords:
+	@echo "export ADMIN_PASSWORD=admin_password"
+	@echo "export MANAGER_PASSWORD=manager_password"
+	@echo "export USER_PASSWORD=user_password"
+
 # https://stackoverflow.com/questions/6405127/how-do-i-specify-a-password-to-psql-non-interactively
 connect:
 	psql postgres://${DB_USER}:${URL_ENCODED_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Knoblauchpilze/template-go
 go 1.26.0
 
 require (
-	github.com/Knoblauchpilze/backend-toolkit v0.4.4
+	github.com/Knoblauchpilze/backend-toolkit v0.4.5
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/stretchr/testify v1.11.1
 )
@@ -11,7 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Knoblauchpilze/backend-toolkit v0.4.4 h1:mNN+Wx4waQf70mUVdJSiORI2tJaSBYLL1+sZQjp9MSs=
-github.com/Knoblauchpilze/backend-toolkit v0.4.4/go.mod h1:ea2MveWrSp5AaetBMwO7bZ9WuT92POjh4X4A538FRwA=
+github.com/Knoblauchpilze/backend-toolkit v0.4.5 h1:IrTdEWwmYGRlBuBooAj1qR5u6IaVQqQpFcHXBknH4Eo=
+github.com/Knoblauchpilze/backend-toolkit v0.4.5/go.mod h1:1hTdiPxclDEIWuqXAXtWGcpfCmCdI6ZUQ6cAeToKtSU=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -8,8 +8,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
-github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
+github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
# Work

E2E tests are failing, see [CI run](https://github.com/Knoblauchpilze/template-go/actions/runs/23135233190/job/67198343044):

<img width="668" height="257" alt="image" src="https://github.com/user-attachments/assets/ff742d3a-7cff-4688-bc33-89dddf550a45" />

The problem is that:
* the CI workflow uses the service containers to instantiate a postgres instance
* we could use the same approach to run the `template-go` image
* but as the database would not exist this step would fail as the container would never be ready

<img width="399" height="175" alt="image" src="https://github.com/user-attachments/assets/a1564009-9f84-457f-b6f8-1b467c778e5b" />

* we cannot have service containers at the step level
* the container seems to sometimes just fail

# Test

The tests are sometimes succeeding and sometimes not.

# Future work

A proper solution would be to:
* have a [initdb](https://www.postgresql.org/docs/7.0/app-initdb.htm) script to create the users and database
* have the service perform the migration when starting up

Those two steps would make it possible to have the service run as a service container and benefit from the tooling that GitHub provides to guarantee health, etc.

This would most likely make the tests more resilient.

